### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Ready](https://badge.waffle.io/movielala/VideoThumbnailViewKit.png?label=Ready&title=Ready)](https://waffle.io/movielala/VideoThumbnailViewKit)
 [![StackOverflow](https://img.shields.io/badge/StackOverflow-Ask%20a%20question!-blue.svg)](http://stackoverflow.com/questions/ask?tags=VideoThumbnailViewKit+ios+swift)
 [![Join the chat at https://gitter.im/mobileplayer/mobileplayer-ios](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/movielala/VideoThumbnailViewKit)
-[![Cocoapods](https://img.shields.io/cocoapods/v/VideoThumbnailViewKit.svg)](https://img.shields.io/cocoapods/v/VideoThumbnailViewKit.svg)
+[![CocoaPods](https://img.shields.io/cocoapods/v/VideoThumbnailViewKit.svg)](https://img.shields.io/cocoapods/v/VideoThumbnailViewKit.svg)
 
 
 ![alt tag](http://i60.tinypic.com/ma8g09.png)


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
